### PR TITLE
Make the docs have a top-level index

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,7 +1,8 @@
 site_name: OpenWorm
 theme: readthedocs
 pages:
-  - [index.md, Introduction]
+  - [index.md, Index]
+  - [intro.md, Introduction]
   - [background.md, Background]
   - [fullhistory.md, History]
   - [releases.md, Releases]

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,7 +1,7 @@
 site_name: OpenWorm
 theme: readthedocs
 pages:
-  - [intro.md, Introduction]
+  - [index.md, Introduction]
   - [background.md, Background]
   - [fullhistory.md, History]
   - [releases.md, Releases]


### PR DESCRIPTION
Currently, the docs 404 when no particular page is accessed.

This fixes that.