### PR TITLE
basic Circle-CI build

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -25,8 +25,8 @@ jobs:
     steps:
       - install
       - run: mkdocs build
-      - store_artifacts: # Upload test summary for display in Artifacts: https://circleci.com/docs/2.0/artifacts/
-          path: site
+      - store_artifacts:
+          path: site  # could directly deploy this directory instead?
 
 workflows:
   version: 2

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,46 @@
+version: 2.1
+defaults: &defaults
+  working_directory: ~/repo
+  docker:
+    - image: circleci/python:3.6
+commands:
+  install:
+    steps:
+      - checkout
+      - run: sudo chown -R circleci:circleci /usr/local/bin
+      - run: sudo chown -R circleci:circleci /usr/local/lib/python3.6/site-packages
+      - restore_cache:
+          keys:
+            - dependency-cache-{{ .Environment.CIRCLE_PREVIOUS_BUILD_NUM }}
+            - dependency-cache-
+      - run: pip install -U mkdocs
+      - save_cache:
+          key: dependency-cache-{{ .Environment.CIRCLE_BUILD_NUM }}
+          paths:
+            - "/usr/local/bin"
+            - "/usr/local/lib/python3.6/site-packages"
+jobs:
+  mkdocs:
+    <<: *defaults
+    steps:
+      - install
+      - run: mkdocs build
+      - store_artifacts: # Upload test summary for display in Artifacts: https://circleci.com/docs/2.0/artifacts/
+          path: site
+
+workflows:
+  version: 2
+  test:
+    jobs:
+      - mkdocs
+  poll:
+    triggers:
+      - schedule:
+          # every hour
+          cron: "0 * * * *"
+          filters:
+            branches:
+              only:
+                - master
+    jobs:
+      - mkdocs

--- a/README.md
+++ b/README.md
@@ -1,5 +1,20 @@
 # openworm_docs
 
-Documentation for OpenWorm, hosted at http://docs.openworm.org.  Information on contributing available at:
+Documentation for OpenWorm, hosted at <http://docs.openworm.org>.
 
-http://docs.openworm.org/en/latest/community#contributing-to-the-openworm-documentation
+[![CircleCI][CI-badge]][CI]
+
+Simply modifying the markdown files in this repository should automatically
+trigger the site to be built and updated via [Read the Docs:dev-openworm-docs](https://readthedocs.org/projects/dev-openworm-docs).
+More information on contributing to this documentation is available at
+[docs.openworm.org/community][Contributing] (which is generated from
+[docs/community.md][Contributing-local]).
+
+For information on OpenWorm itself and contributing in general, see
+<http://openworm.org> and [getting involved].
+
+[Contributing]: http://docs.openworm.org/en/latest/community#contributing-to-the-openworm-documentation
+[Contributing-local]: docs/community.md
+[getting involved]: http://openworm.org/get_involved.html
+[CI-badge]: https://img.shields.io/circleci/build/gh/openworm/openworm_docs?logo=circleci
+[CI]: https://circleci.com/gh/openworm/openworm_docs


### PR DESCRIPTION
Add CI tests

- fixes #56
- prerequisite for #55
- also builds `master` hourly (takes just 10 sec to build and 20 to upload the build artifacts)
- updates README.md with some basic information

Currently only tests that `mkdocs build` succeeds without errors.

- status: https://circleci.com/gh/openworm
- example artifacts: https://circleci.com/gh/openworm/openworm_docs/3#artifacts/containers/0
- status (this branch): [![CircleCI](https://circleci.com/gh/openworm/openworm_docs/tree/ci.svg?style=svg)](https://circleci.com/gh/openworm/openworm_docs/tree/ci)
- status (master): [![CircleCI](https://circleci.com/gh/openworm/openworm_docs.svg?style=svg)](https://circleci.com/gh/openworm/openworm_docs)
- status (master, shields style): ![CircleCI](https://img.shields.io/circleci/build/gh/openworm/openworm_docs?logo=circleci)
- current readthedocs: [![Documentation Status](https://readthedocs.org/projects/dev-openworm-docs/badge/?version=latest)](https://dev-openworm-docs.readthedocs.io/en/latest/?badge=latest) @mwatts15 any idea why this isn't green?

References:

- https://www.mkdocs.org/
- https://circleci.com/docs/2.0/gh-bb-integration/
- https://circleci.com/docs/2.0/configuration-reference/
https://circleci.com/docs/2.0/executor-types/
- https://circleci.com/docs/2.0/circleci-images/
- https://circleci.com/docs/2.0/language-python/
- https://circleci.com/docs/2.0/artifacts/
---
- https://openworm.slack.com/apps/A0F7VRE7N-circleci
- https://docs.readthedocs.io/en/stable/webhooks.html