### PR TITLE
deploy to github-pages

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -38,7 +38,10 @@ workflows:
   version: 2
   test:
     jobs:
-      - mkdocs
+      - mkdocs:
+          filters:
+            branches:
+              ignore: /^gh-pages/
   poll:
     triggers:
       - schedule:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -31,8 +31,16 @@ jobs:
     steps:
       - install
       - run: mkdocs build
+      - add_ssh_keys:
+          fingerprints:
+            - "ad:f1:51:b7:68:cb:19:08:b2:7d:63:e3:eb:79:1a:63"
+      - deploy:
+          command: |
+            if [ "${CIRCLE_BRANCH}" == "master" ]; then
+              mkdocs gh-deploy
+            fi
       - store_artifacts:
-          path: site  # could directly deploy this directory instead?
+          path: site
 
 workflows:
   version: 2

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -32,6 +32,8 @@ jobs:
       - install
       - run: mkdocs build
       - add_ssh_keys:
+          # tell CI to use openworm-bot@github's ssh key (for deploy permissions)
+          # https://circleci.com/docs/2.0/add-ssh-key/
           fingerprints:
             - "ad:f1:51:b7:68:cb:19:08:b2:7d:63:e3:eb:79:1a:63"
       - deploy:
@@ -49,12 +51,11 @@ workflows:
       - mkdocs:
           filters:
             branches:
-              ignore: /^gh-pages/
+              ignore: /^gh-pages/  # no tests exist on deployed pages branch
   poll:
     triggers:
       - schedule:
-          # every hour
-          cron: "0 * * * *"
+          cron: "0 * * * *"  # every hour
           filters:
             branches:
               only:

--- a/CNAME
+++ b/CNAME
@@ -1,0 +1,1 @@
+docs.openworm.org

--- a/docs/CNAME
+++ b/docs/CNAME
@@ -1,0 +1,1 @@
+docs.openworm.org


### PR DESCRIPTION
- [x] add continuous integration (CI) (fixed by #56 & #57)
  + [x] get CI to regularly build the site
  + [x] test builds of branches and PRs before merge
  + [x] full build env control
- [x] deploy `mkdocs`-generated static site directly to `gh-pages`
  + [x] get CI to automatically deploy the site to `gh-pages` branch
  + [ ] http://docs.openworm.org is configured to point to github.io
    * update openworm.org's CNAME DNS record for the docs subdomain to point to openworm.github.io as per https://help.github.com/en/github/working-with-github-pages/configuring-a-custom-domain-for-your-github-pages-site (i.e. make docs.openworm.org point to openworm_docs)
  + [x] openworm.github.io/openworm_docs is configured to expect http://docs.openworm.org (without affecting openworm.github.io expecting http://openworm.org)
  + no dependency on any other web services
- fixes #60
- related to #64

We already rely on GitHub pages for the main site (https://github.com/openworm/openworm.github.io).