### PR TITLE
Fix: preserve PR preview deploys during master deploy

### DIFF
--- a/.github/workflows/mkdocs.yml
+++ b/.github/workflows/mkdocs.yml
@@ -145,9 +145,23 @@ jobs:
         if [[ "$LAST_BUILT_SHA" = "$SHA"  ]] && git diff origin/gh-pages --exit-code $REPO_METADATA_SHAS ; then
             echo "No changes in repo metadata. Skipping deploy"
         else
+            # Save any existing preview deployments before ghp-import wipes gh-pages
+            if [ -d "preview" ]; then
+              cp -r preview /tmp/preview-backup
+              echo "Saved preview/ directory for restoration after deploy"
+            fi
+
             git checkout -
             ghp-import -o -n site
             git checkout gh-pages
+
+            # Restore preview deployments
+            if [ -d "/tmp/preview-backup" ]; then
+              cp -r /tmp/preview-backup preview
+              git add preview/
+              echo "Restored preview/ directory"
+            fi
+
             echo -n $SHA > last_build_sha
             git add last_build_sha
             mv $REPO_METADATA_SHAS.temp $REPO_METADATA_SHAS


### PR DESCRIPTION
## Summary
- The `ghp-import -o` flag in the master deploy step creates an orphan gh-pages branch, which **wipes out all PR preview directories** (`preview/<branch>/`)
- This caused 404s on `docs.openworm.org/preview/integrate-design-documents/` after PRs #115/#116 merged to master
- Fix: save and restore the `preview/` directory around the `ghp-import -o` call

## Test plan
- [ ] Merge this PR to master
- [ ] Verify the master deploy workflow succeeds
- [ ] Re-trigger the integrate-design-documents PR build (push a commit or close/reopen PR #114)
- [ ] Verify `https://docs.openworm.org/preview/integrate-design-documents/` resolves (no more 404)
- [ ] Merge another PR to master and confirm the preview directory survives

🤖 Generated with [Claude Code](https://claude.com/claude-code)